### PR TITLE
fixed: exception about missing event loop in thread-pool when other processes create their own event loops

### DIFF
--- a/waapi/client/client.py
+++ b/waapi/client/client.py
@@ -63,18 +63,22 @@ class WaapiClient(UnsubscribeHandler):
         self._callback_executor = callback_executor
         self._client_thread = None
         """:type: Thread"""
-
-        self._loop = asyncio.get_event_loop()
-        if not self._loop.is_running():
-            if not self._loop.is_closed():
+        # ++++[community fix]
+        try:
+            self._loop = asyncio.get_event_loop()
+        except Exception as e:
+            print(e)
+            self._loop = None
+        if not self._loop or not self._loop.is_running():
+            if self._loop and not self._loop.is_closed():
                 self._loop.close()
+        # ----[community fix]
             if platform == 'win32':
                 #  Prefer the ProactorEventLoop event loop on Windows
                 self._loop = asyncio.ProactorEventLoop()
             else:
                 self._loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self._loop)
-
         self._decoupler = None
         """:type: AutobahnClientDecoupler"""
 


### PR DESCRIPTION
With current waapi-client, we get an error looking like this

```
 RuntimeError: There is no current event loop in the thread pool ...
```

when the caller process already uses an asyncio event loop.

So to solve this problem, I had to use this patch locally. 
Hope this patch helps with a sound solution to this scenario, which could happen often if external IPC is involved.


